### PR TITLE
Add in-repo addons migration path to RFC #985

### DIFF
--- a/text/0985-v2-addon-by-default.md
+++ b/text/0985-v2-addon-by-default.md
@@ -925,6 +925,17 @@ Key differences from a published addon:
 
 The consuming app's build tooling (Vite/Embroider) handles the transpilation. This is much simpler to maintain for workspace-internal code.
 
+#### In-Repo Addons
+
+Classic in-repo addons (the `lib/` directory pattern) are v1 constructs. To create the v2 equivalent, use your package manager's workspace features to establish them as real package dependencies:
+
+1. Create a directory for the addon (e.g. `packages/my-internal-addon/` or keep `lib/my-internal-addon/`)
+2. Give it a `package.json` with `ember-addon.version: 2`
+3. Add it to your workspace configuration (e.g. pnpm `workspace.yaml` or `package.json` `"workspaces"`)
+4. Install it as a dependency of the consuming app
+
+These in-repo addons will typically be "unbuilt" -- they point `exports` at source files as described in the Unpublished Addons section above. This avoids the need for a separate build step while still giving you proper package boundaries and clean imports. The consuming app's Vite/Embroider build handles all transpilation.
+
 #### Publishing
 
 1. Write code in `src/`, tests with `#src/*` imports


### PR DESCRIPTION
## Summary

Addresses ef4's review comment on emberjs/rfcs#985 that the RFC should explain what to do about in-repo addons.

- Added "In-Repo Addons" subsection under "How we teach this" explaining that classic `lib/` in-repo addons are v1 constructs
- Documents the migration path: use workspace features to establish them as real package dependencies
- Notes they'll typically be "unbuilt" addons (pointing exports at source, no separate build step)
- References the existing "Unpublished Addons" section for the package.json configuration

## Test plan

- [ ] Review that the guidance aligns with ef4's comment about using package manager workspace features
- [ ] Verify the section flows naturally between "Unpublished Addons in a Monorepo" and "Publishing"

🤖 Generated with [Claude Code](https://claude.com/claude-code)